### PR TITLE
1.4.5 - Fixed an access violation exception when analyzing images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.5]
+
+### Fixed
+- Fixed an access violation exception when analyzing images.
+
 ## [1.4.4]
 
 ### Fixed

--- a/src/ImageResizer.Plugins.AutoCrop/Analyzers/BorderAnalyzer.cs
+++ b/src/ImageResizer.Plugins.AutoCrop/Analyzers/BorderAnalyzer.cs
@@ -78,7 +78,7 @@ namespace ImageResizer.Plugins.AutoCrop.Analyzers
                 {
                     var row = s0 + y * s;
                     
-                    var p = w * BitsPerPixel;
+                    var p = (w - 1) * BitsPerPixel;
                     var b = row[p];
                     var g = row[p + 1];
                     var r = row[p + 2];
@@ -219,7 +219,7 @@ namespace ImageResizer.Plugins.AutoCrop.Analyzers
                 {
                     var row = s0 + y * s;
                     
-                    var p = w * BitsPerPixel;
+                    var p = (w - 1) * BitsPerPixel;
                     var b = row[p];
                     var g = row[p + 1];
                     var r = row[p + 2];

--- a/src/ImageResizer.Plugins.AutoCrop/ImageResizer.Plugins.AutoCrop.nuspec
+++ b/src/ImageResizer.Plugins.AutoCrop/ImageResizer.Plugins.AutoCrop.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>ImageResizer.Plugins.AutoCrop</id>
-        <version>1.4.4</version>
+        <version>1.4.5</version>
         <title>ImageResizer.Plugins.AutoCrop</title>
         <authors>Geta AS</authors>
         <owners>Geta AS</owners>

--- a/src/ImageResizer.Plugins.AutoCrop/Properties/AssemblyInfo.cs
+++ b/src/ImageResizer.Plugins.AutoCrop/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.4.0")]
-[assembly: AssemblyFileVersion("1.4.4.0")]
+[assembly: AssemblyVersion("1.4.5.0")]
+[assembly: AssemblyFileVersion("1.4.5.0")]


### PR DESCRIPTION
Due to an issue with looping the right side of the image, when reading the last row, the plugin would sometimes traverse into protected memory.